### PR TITLE
Cray patch for big cases included

### DIFF
--- a/comm_mpi.f
+++ b/comm_mpi.f
@@ -22,7 +22,10 @@ c      endif
 
       ! check upper tag size limit
       call mpi_attr_get(MPI_COMM_WORLD,MPI_TAG_UB,nval,flag,ierr)
-      if (nval.lt.(10000+max(lp,lelg))) then
+c     to avoid problems with MPI_TAG_UB on Cray we change
+c     tags from global (eg) to local (e) element number
+c      if (nval.lt.(10000+max(lp,lelg))) then
+      if (nval.lt.(10000+lp)) then
          if(nid.eq.0) write(6,*) 'ABORT: MPI_TAG_UB too small!'
          call exitt
       endif
@@ -211,6 +214,25 @@ C
       real*4 buf(1)
       len = lenm
       jnid = mpi_any_source
+
+      call mpi_recv (buf,len,mpi_byte
+     $              ,jnid,mtype,nekcomm,status,ierr)
+c
+      if (len.gt.lenm) then 
+          write(6,*) nid,'long message in mpi_crecv:',len,lenm
+          call exitt
+      endif
+c
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine crecv2(mtype,buf,lenm,jnid)
+      include 'mpif.h'
+      common /nekmpi/ nid,np,nekcomm,nekgroup,nekreal
+      integer status(mpi_status_size)
+C
+      real*4 buf(1)
+      len = lenm
 
       call mpi_recv (buf,len,mpi_byte
      $              ,jnid,mtype,nekcomm,status,ierr)

--- a/navier0.f
+++ b/navier0.f
@@ -149,7 +149,9 @@ c-----------------------------------------------------------------------
 
          mid   = gllnid(eg)
          e     = gllel (eg)
-         mtype = 2000+eg
+c     tag for sending and receiving changed from global (eg) to 
+c     local (e) element number to avoid problems with MPI_TAG_UB on Cray
+         mtype = 2000+e
 
          if (nid.eq.0) then
             if (mid.eq.0) then
@@ -157,14 +159,14 @@ c-----------------------------------------------------------------------
                call  copy(buf(2),a(1,e),lda)
             else
                call csend (mtype,dum,wdsize,mid,nullpid)
-               call crecv (mtype,buf,len)
+               call crecv2 (mtype,buf,len,mid)
             endif
             write(49,49) mid,ibuf(1),(buf(k+1),k=1,lda)
    49       format(2i12,1p3e16.7)
          elseif (nid.eq.mid) then
             call icopy(buf(1),ia(e),1)
             call  copy(buf(2),a(1,e),lda)
-            call crecv (mtype,dum,wdsize)
+            call crecv2 (mtype,dum,wdsize,0)
             call csend (mtype,buf,len,node0,nullpid)
          endif
       enddo

--- a/navier5.f
+++ b/navier5.f
@@ -2994,15 +2994,17 @@ c-----------------------------------------------------------------------
       if (nid.eq.0) open(unit=29,file='rea.new')
 
       do eg=1,nelgt
-         mtype = eg
          call nekgsync()          !  belt
          jnid = gllnid(eg)
          e    = gllel (eg)
+c     tag for sending and receiving changed from global (eg) to 
+c     local (e) element number to avoid problems with MPI_TAG_UB on Cray
+         mtype = e
          if (jnid.eq.0 .and. nid.eq.0) then
             call get_el(xt,xm1(1,1,1,e),ym1(1,1,1,e),zm1(1,1,1,e))
             call out_el(xt,eg)
          elseif (nid.eq.0) then
-            call crecv(mtype,xt,len)
+            call crecv2(mtype,xt,len,jnid)
             call out_el(xt,eg)
          elseif (jnid.eq.nid) then
             call get_el(xt,xm1(1,1,1,e),ym1(1,1,1,e),zm1(1,1,1,e))

--- a/prepost.f
+++ b/prepost.f
@@ -439,20 +439,23 @@ C     Dump header
             if (jnid.eq.0) then
                call fill_tmp(tdump,id,ie)
             else
-               mtype=2000+ieg
+c	tag for sending and receiving changed from global (eg) to local (e) element number
+c	to avoid problems with MPI_TAG_UB on Cray
+               mtype=2000+ie
                len=4*id*nxyz
                dum1=0.
                call csend (mtype,dum1,wdsize,jnid,nullpid)
-               call crecv (mtype,tdump,len)
+               call crecv2 (mtype,tdump,len,jnid)
             endif
             if(ierr.eq.0) call out_tmp(id,p66,ierr)
          elseif (nid.eq.jnid) then
             call fill_tmp(tdump,id,ie)
             dum1=0.
-
-            mtype=2000+ieg
+c       tag for sending and receiving changed from global (eg) to local (e) element number
+c       to avoid problems with MPI_TAG_UB on Cray
+            mtype=2000+ie
             len=4*id*nxyz
-            call crecv (mtype,dum1,wdsize)
+            call crecv2 (mtype,dum1,wdsize,node0)
             call csend (mtype,tdump,len,node0,nullpid)
          endif
       enddo


### PR DESCRIPTION
Solve tag problem that was found when running big cases (more than
2_10_*6 elements) on the cray machine at KTH. To solve it we exchanged the global
element number in the tag with the local one on the destination
processor (unique one), so the tag values stay much lower than the limit
on cray.
